### PR TITLE
添加账号失效推送

### DIFF
--- a/src/main/java/top/misec/BiliMain.java
+++ b/src/main/java/top/misec/BiliMain.java
@@ -24,16 +24,13 @@ public class BiliMain {
         }
         //读取环境变量
         Verify.verifyInit(args[0], args[1], args[2]);
-        serverMsgPush = args[3];
+        if (args.length > 3) { //@happy88888 赋值前先判断，否则为null
+        	serverMsgPush = args[3];
+        }
         //每日任务65经验
         logger.debug("-----任务启动-----");
         DailyTask dailyTask = new DailyTask();
-        dailyTask.doDailyTask();
-
-        if (serverMsgPush != null) {
-            ServerPush serverPush = new ServerPush(serverMsgPush);
-            serverPush.pushMsg("BILIBILIHELPER已完成所有任务", "自动推送");
-        }
+        dailyTask.doDailyTask(serverMsgPush);//@happy88888 将SCKEY传到dailyTask模块处理
     }
 
 }


### PR DESCRIPTION
更新
1. 添加在账号失效时用server酱进行消息推送，避免账号失效还推送正常消息误导用户。

发现问题：
SESSDATA失效时抛出空指针异常，并没有执行后面的记录日志的操作，问题尚未解决