### PR TITLE
修复送辣条时报空指针的问题

### DIFF
--- a/src/main/java/top/misec/task/GiveGift.java
+++ b/src/main/java/top/misec/task/GiveGift.java
@@ -126,7 +126,8 @@ public class GiveGift implements Task {
     public String getRoomInfoOld(String mid) {
         JsonObject pJson = new JsonObject();
         pJson.addProperty("mid", Integer.parseInt(mid));
-        return HttpUtil.doGet("http://api.live.bilibili.com/room/v1/Room/getRoomInfoOld", pJson)
+        String urlPram = "?mid=" + mid;
+        return HttpUtil.doGet("http://api.live.bilibili.com/room/v1/Room/getRoomInfoOld" + urlPram)
                 .get("data").getAsJsonObject()
                 .get("roomid").getAsString();
     }


### PR DESCRIPTION
报错日志：
```
-----B站直播送出即将过期的礼物开始-----

💔赠送礼物异常 :

java.lang.NullPointerException: null 
at top.misec.task.GiveGift.getRoomInfoOld(GiveGift.java:130) ~[classes/:?] 
at top.misec.task.GiveGift.getuidAndRid(GiveGift.java:183) ~[classes/:?] 
at top.misec.task.GiveGift.run(GiveGift.java:54) [classes/:?] 
at top.misec.task.DailyTask.doDailyTask(DailyTask.java:42) [classes/:?] 
at top.misec.BiliMain.main(BiliMain.java:36) [classes/:?] 
at org.codehaus.mojo.exec.ExecJavaMojo$1.run(ExecJavaMojo.java:254) [exec-maven-plugin-3.0.0.jar:?] 
at java.lang.Thread.run(Thread.java:748) [?:1.8.0_275] 
-----B站直播送出即将过期的礼物结束-----
```
另外，B站API返回的json都带有`code`字段用于标识错误码，建议在使用json前判断`code`是否为0，以避免可能出现的错误。