### PR TITLE
Serverchan更新至Turbo通道

### DIFF
--- a/src/main/java/top/misec/apiquery/ApiList.java
+++ b/src/main/java/top/misec/apiquery/ApiList.java
@@ -6,7 +6,8 @@ package top.misec.apiquery;
  */
 public class ApiList {
 
-    public static String ServerPush = "https://sctapi.ftqq.com/";
+    public static String ServerPush = "https://sc.ftqq.com/";
+    public static String ServerPushV2 = "https://sctapi.ftqq.com/";
     public static String ServerPushTelegram = "https://api.telegram.org/bot";
     public static String LOGIN = "https://api.bilibili.com/x/web-interface/nav";
     public static String Manga = "https://manga.bilibili.com/twirp/activity.v1.Activity/ClockIn";

--- a/src/main/java/top/misec/apiquery/ApiList.java
+++ b/src/main/java/top/misec/apiquery/ApiList.java
@@ -6,7 +6,7 @@ package top.misec.apiquery;
  */
 public class ApiList {
 
-    public static String ServerPush = "https://sc.ftqq.com/";
+    public static String ServerPush = "https://sctapi.ftqq.com/";
     public static String ServerPushTelegram = "https://api.telegram.org/bot";
     public static String LOGIN = "https://api.bilibili.com/x/web-interface/nav";
     public static String Manga = "https://manga.bilibili.com/twirp/activity.v1.Activity/ClockIn";


### PR DESCRIPTION
近期Server酱已发布升级公告，将于4月下线库中当前所用的api（sc.ftqq.com），原文如下：

> [因为微信发布公告将在4月底下线模板消息，Server酱开发了以企业微信为主的多通道新版（ Turbo版 sct.ftqq.com ）。旧版将在4月后下线，请尽快完成配置的更新。
](https://sc.ftqq.com/9.version)

建议可以尽快引导切换至该通道。
