### PR TITLE
完善推送未配置正确的ftKey和chatId时的日志提示

### DIFF
--- a/src/main/java/top/misec/task/ServerPush.java
+++ b/src/main/java/top/misec/task/ServerPush.java
@@ -51,7 +51,7 @@ public class ServerPush {
         if (null != push) {
             PushHelper.push(push, builder.build(), LoadFileResource.loadFile("/tmp/daily.log"));
         } else {
-            log.warn("未配置正确的ftKey和chatId,本次执行将不推送日志");
+            log.info("未配置正确的ftKey和chatId,本次执行将不推送日志");
         }
     }
 }

--- a/src/main/java/top/misec/task/ServerPush.java
+++ b/src/main/java/top/misec/task/ServerPush.java
@@ -46,12 +46,12 @@ public class ServerPush {
             builder = builder.token(ftKey).chatId(chatId);
             push = new TelegramPush();
             log.info("本次执行推送日志到Telegram");
-        } else {
-            log.info("未配置server酱,本次执行不推送日志到微信");
-            log.info("未配置Telegram,本次执行不推送日志到Telegram");
-        }
+        } 
+        
         if (null != push) {
             PushHelper.push(push, builder.build(), LoadFileResource.loadFile("/tmp/daily.log"));
+        } else {
+            log.warn("未配置正确的ftKey和chatId,本次执行将不推送日志");
         }
     }
 }


### PR DESCRIPTION
之前当ftKey不为null,且不符合推送规则时，不会产生提示信息